### PR TITLE
Add guessing `image/heic` mime type by bytes

### DIFF
--- a/Sources/MIME/MIME+Guessing.swift
+++ b/Sources/MIME/MIME+Guessing.swift
@@ -132,7 +132,8 @@ extension MIME {
             return .init("image/webp")
         } else if bytesCount > 3 && bytes[0...3] == [0x00, 0x00, 0x01, 0x00] {
             return .init("image/x-icon")
-        } else if bytesCount > 11 && (bytes[8...11] == [0x68, 0x65, 0x69, 0x63] || bytes[8...11] == [0x68, 0x65, 0x69, 0x78]) {
+        } else if bytesCount > 11 &&
+            (bytes[8...11] == [0x68, 0x65, 0x69, 0x63] || bytes[8...11] == [0x68, 0x65, 0x69, 0x78]) {
             return .init("image/heic")
         } else if
             (

--- a/Sources/MIME/MIME+Guessing.swift
+++ b/Sources/MIME/MIME+Guessing.swift
@@ -132,6 +132,8 @@ extension MIME {
             return .init("image/webp")
         } else if bytesCount > 3 && bytes[0...3] == [0x00, 0x00, 0x01, 0x00] {
             return .init("image/x-icon")
+        } else if bytesCount > 11 && (bytes[8...11] == [0x68, 0x65, 0x69, 0x63] || bytes[8...11] == [0x68, 0x65, 0x69, 0x78]) {
+            return .init("image/heic")
         } else if
             (
                 bytesCount > 7 &&

--- a/Tests/MIMETests/MIMETests.swift
+++ b/Tests/MIMETests/MIMETests.swift
@@ -984,5 +984,17 @@ final class MIMETests: XCTestCase {
         XCTAssertEqual(mime.subtype, "octet-stream")
         XCTAssertNil(mime.ext)
         XCTAssertEqual("\(mime)", "application/octet-stream")
+
+        // Arrange
+        data = Data([0x52, 0x49, 0x46, 0x46, 0x46, 0x46, 0x46, 0x46, 0x68, 0x65, 0x69, 0x63])
+
+        // Act
+        mime = MIME.guess(from: data)
+
+        // Assert
+        XCTAssertEqual(mime.type, "image")
+        XCTAssertEqual(mime.subtype, "heic")
+        XCTAssertEqual(mime.ext, "heic")
+        XCTAssertEqual("\(mime)", "image/heic")
     }
 }


### PR DESCRIPTION
## Summary
This repo doesn't guess HEIC file mime type with data. When I tried to guess HEIC file from data using MIME.guess(data: data), I got the result with video/mp4 mime type which is absolutely wrong.

### Solution
Possible solution is that on the guess(data: Data) method, need to add one if else case by checking bytesCount > 11 && (bytes[8...11] == [0x68, 0x65, 0x69, 0x63] || bytes[8...11] == [0x68, 0x65, 0x69, 0x78] and return .init("image/heic")
The whole code should look like that:

```
  if bytesCount > 11 && (bytes[8...11] == [0x68, 0x65, 0x69, 0x63] || bytes[8...11] == [0x68, 0x65, 0x69, 0x78]) {
       return .init("image/heic")
  }
```
### How I get this solution
I found the solution on this [REPO:](https://github.com/sendyhalim/Swime/blob/master/Sources/MimeType.swift).
Tested it using the SD attachment component on my device manually with about 3 examples.

## Issue
[#1](https://github.com/chaqmoq/mime/issues/1)

## Checklist
Before you submit this PR, please make sure:
1. [x] You have successfully built your changes on your local computer
2. [x] You have covered your code with tests
3. [x] You have run all the tests on your local computer
4. [x] Your code adheres to [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines)
5. [x] Your code adheres to [SwiftLint Formatting Rules](https://realm.github.io/SwiftLint/rule-directory.html) and doesn't introduce new formatting errors and warnings
6. [x] You have checked for typos
7. [ ] You have updated the inline code documentation and [README](https://github.com/chaqmoq/mime/blob/master/README.md) accordingly

[![Actions Status](https://github.com/chaqmoq/mime/actions/workflows/development.yaml/badge.svg?branch=elyahk:add-heic-file-mime)](https://github.com/chaqmoq/mime/actions/workflows/development.yaml?branch=elyahk:add-heic-file-mime)
